### PR TITLE
feat: Dependabotの導入

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,76 @@
+version: 2
+updates:
+  # Production dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+    reviewers:
+      - "sasakihasuto"
+    assignees:
+      - "sasakihasuto"
+    allow:
+      - dependency-type: "direct"
+      - dependency-type: "indirect"
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        exclude-patterns:
+          - "@types/*"
+          - "eslint*"
+          - "typescript"
+          - "tailwindcss"
+      types-dependencies:
+        patterns:
+          - "@types/*"
+      linting-dependencies:
+        patterns:
+          - "eslint*"
+          - "prettier*"
+      # Tailwind CSS関連をグループ化
+      tailwind-dependencies:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+    ignore:
+      # メジャーバージョンアップは慎重に手動で管理
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@tailwindcss/postcss"
+        update-types: ["version-update:semver-major"]
+      # React関連は現在v19を使用しているのでメジャーアップデートのみ除外
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actionsの依存関係も管理
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "github-actions"
+      - "ci"


### PR DESCRIPTION
## 概要
Dependabotを導入して、依存関係の自動更新を設定しました。

## 変更内容
- \`.github/dependabot.yaml\` を追加
- npm依存関係の週次自動更新を設定
- GitHub Actionsの依存関係の週次自動更新を設定
- 依存関係をグループ化して管理しやすく設定

## 設定詳細
### npm依存関係
- **スケジュール**: 毎週月曜日 04:00 (JST)
- **対象**: 直接・間接依存関係両方
- **グループ化**:
  - 開発用依存関係
  - 型定義関係（@types/*）
  - Linting関係（eslint*, prettier*）
  - Tailwind CSS関係

### GitHub Actions
- **スケジュール**: 毎週月曜日 04:00 (JST)
- **ラベル**: \`github-actions\`, \`ci\`

### 除外設定
メジャーバージョンアップは手動管理するため、以下を除外:
- Next.js
- React関係
- Tailwind CSS関係

## 効果
- 依存関係のセキュリティ更新の自動化
- 定期的な依存関係のメンテナンス
- 開発者の手動更新作業の軽減