### PR TITLE
fix(ci): pin pnpm to 10.28.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: pnpm
 
       - run: |
           echo "AFTER_NODE_SETUP head: $(head -1 pnpm-lock.yaml)"
@@ -66,7 +65,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: pnpm
 
       - run: |
           echo "AFTER_NODE_SETUP head: $(head -1 pnpm-lock.yaml)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,12 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - run: |
+          echo "pnpm version: $(pnpm --version)"
+          which pnpm
+          pnpm config get minimumReleaseAge || true
+          head -1 pnpm-lock.yaml
+          grep -c '^---$' pnpm-lock.yaml || true
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
 
@@ -42,5 +48,11 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - run: |
+          echo "pnpm version: $(pnpm --version)"
+          which pnpm
+          pnpm config get minimumReleaseAge || true
+          head -1 pnpm-lock.yaml
+          grep -c '^---$' pnpm-lock.yaml || true
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,10 @@ jobs:
           echo "AFTER_NODE_SETUP head: $(head -1 pnpm-lock.yaml)"
           echo "AFTER_NODE_SETUP dashes: $(grep -c '^---$' pnpm-lock.yaml || true)"
           echo "AFTER_NODE_SETUP md5: $(md5sum pnpm-lock.yaml)"
-      - run: pnpm install --frozen-lockfile
+      - run: |
+          echo "BEFORE_INSTALL head: $(head -1 pnpm-lock.yaml)"
+          echo "BEFORE_INSTALL md5: $(md5sum pnpm-lock.yaml)"
+          pnpm install --frozen-lockfile || (echo "INSTALL_FAILED head after: $(head -1 pnpm-lock.yaml)"; echo "INSTALL_FAILED md5 after: $(md5sum pnpm-lock.yaml)"; echo "INSTALL_FAILED dashes: $(grep -c '^---$' pnpm-lock.yaml)"; exit 1)
       - run: pnpm run lint
 
   build:
@@ -70,5 +73,8 @@ jobs:
           echo "AFTER_NODE_SETUP head: $(head -1 pnpm-lock.yaml)"
           echo "AFTER_NODE_SETUP dashes: $(grep -c '^---$' pnpm-lock.yaml || true)"
           echo "AFTER_NODE_SETUP md5: $(md5sum pnpm-lock.yaml)"
-      - run: pnpm install --frozen-lockfile
+      - run: |
+          echo "BEFORE_INSTALL head: $(head -1 pnpm-lock.yaml)"
+          echo "BEFORE_INSTALL md5: $(md5sum pnpm-lock.yaml)"
+          pnpm install --frozen-lockfile || (echo "INSTALL_FAILED head after: $(head -1 pnpm-lock.yaml)"; echo "INSTALL_FAILED md5 after: $(md5sum pnpm-lock.yaml)"; echo "INSTALL_FAILED dashes: $(grep -c '^---$' pnpm-lock.yaml)"; exit 1)
       - run: pnpm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.28.1
-          standalone: true
+          version: 10.33.0
 
       - run: |
           echo "AFTER_PNPM_SETUP head: $(head -1 pnpm-lock.yaml)"
@@ -57,8 +56,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 10.28.1
-          standalone: true
+          version: 10.33.0
 
       - run: |
           echo "AFTER_PNPM_SETUP head: $(head -1 pnpm-lock.yaml)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - run: |
+          echo "AFTER_CHECKOUT head: $(head -1 pnpm-lock.yaml)"
+          echo "AFTER_CHECKOUT dashes: $(grep -c '^---$' pnpm-lock.yaml || true)"
+          echo "AFTER_CHECKOUT md5: $(md5sum pnpm-lock.yaml)"
+
       - uses: pnpm/action-setup@v6
         with:
           version: 10.28.1
           standalone: true
+
+      - run: |
+          echo "AFTER_PNPM_SETUP head: $(head -1 pnpm-lock.yaml)"
+          echo "AFTER_PNPM_SETUP dashes: $(grep -c '^---$' pnpm-lock.yaml || true)"
+          echo "AFTER_PNPM_SETUP md5: $(md5sum pnpm-lock.yaml)"
 
       - uses: actions/setup-node@v6
         with:
@@ -27,11 +37,9 @@ jobs:
           cache: pnpm
 
       - run: |
-          echo "pnpm version: $(pnpm --version)"
-          which pnpm
-          pnpm config get minimumReleaseAge || true
-          head -1 pnpm-lock.yaml
-          grep -c '^---$' pnpm-lock.yaml || true
+          echo "AFTER_NODE_SETUP head: $(head -1 pnpm-lock.yaml)"
+          echo "AFTER_NODE_SETUP dashes: $(grep -c '^---$' pnpm-lock.yaml || true)"
+          echo "AFTER_NODE_SETUP md5: $(md5sum pnpm-lock.yaml)"
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
 
@@ -40,10 +48,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - run: |
+          echo "AFTER_CHECKOUT head: $(head -1 pnpm-lock.yaml)"
+          echo "AFTER_CHECKOUT dashes: $(grep -c '^---$' pnpm-lock.yaml || true)"
+          echo "AFTER_CHECKOUT md5: $(md5sum pnpm-lock.yaml)"
+
       - uses: pnpm/action-setup@v6
         with:
           version: 10.28.1
           standalone: true
+
+      - run: |
+          echo "AFTER_PNPM_SETUP head: $(head -1 pnpm-lock.yaml)"
+          echo "AFTER_PNPM_SETUP dashes: $(grep -c '^---$' pnpm-lock.yaml || true)"
+          echo "AFTER_PNPM_SETUP md5: $(md5sum pnpm-lock.yaml)"
 
       - uses: actions/setup-node@v6
         with:
@@ -51,10 +69,8 @@ jobs:
           cache: pnpm
 
       - run: |
-          echo "pnpm version: $(pnpm --version)"
-          which pnpm
-          pnpm config get minimumReleaseAge || true
-          head -1 pnpm-lock.yaml
-          grep -c '^---$' pnpm-lock.yaml || true
+          echo "AFTER_NODE_SETUP head: $(head -1 pnpm-lock.yaml)"
+          echo "AFTER_NODE_SETUP dashes: $(grep -c '^---$' pnpm-lock.yaml || true)"
+          echo "AFTER_NODE_SETUP md5: $(md5sum pnpm-lock.yaml)"
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.28.1
 
       - uses: actions/setup-node@v6
         with:
@@ -32,6 +34,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.28.1
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 10.28.1
+          standalone: true
 
       - uses: actions/setup-node@v6
         with:
@@ -42,6 +43,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 10.28.1
+          standalone: true
 
       - uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "protfolio",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.28.1",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,22 +10,22 @@ importers:
     dependencies:
       '@gsap/react':
         specifier: ^2.1.2
-        version: 2.1.2(gsap@3.15.0)(react@19.2.4)
+        version: 2.1.2(gsap@3.15.0)(react@19.2.5)
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
       next:
         specifier: 15.5.12
-        version: 15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 15.5.12(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
       react:
         specifier: ^19.2.4
-        version: 19.2.4
+        version: 19.2.5
       react-dom:
         specifier: ^19.2.3
-        version: 19.2.4(react@19.2.4)
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@eslint/compat':
         specifier: ^2.0.5
@@ -35,7 +35,7 @@ importers:
         version: 4.2.2
       '@types/node':
         specifier: ^25
-        version: 25.3.0
+        version: 25.6.0
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -50,7 +50,7 @@ importers:
         version: 16.2.4(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.2.0
-        version: 4.2.0
+        version: 4.2.2
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -134,9 +134,6 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
-
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
@@ -201,8 +198,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@img/colour@1.0.0':
-    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -560,8 +557,8 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@25.3.0':
-    resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -840,9 +837,6 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
-
-  caniuse-lite@1.0.30001769:
-    resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
@@ -1647,16 +1641,16 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-dom@19.2.4:
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
-      react: ^19.2.4
+      react: ^19.2.5
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react@19.2.4:
-    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   reflect.getprototypeof@1.0.10:
@@ -1801,9 +1795,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  tailwindcss@4.2.0:
-    resolution: {integrity: sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==}
-
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
@@ -1867,8 +1858,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2038,11 +2029,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.8.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
@@ -2084,10 +2070,10 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@gsap/react@2.1.2(gsap@3.15.0)(react@19.2.4)':
+  '@gsap/react@2.1.2(gsap@3.15.0)(react@19.2.5)':
     dependencies:
       gsap: 3.15.0
-      react: 19.2.4
+      react: 19.2.5
 
   '@humanfs/core@0.19.1': {}
 
@@ -2100,7 +2086,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.0.0':
+  '@img/colour@1.1.0':
     optional: true
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -2185,7 +2171,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -2355,9 +2341,9 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@25.3.0':
+  '@types/node@25.6.0':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 7.19.2
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -2654,8 +2640,6 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-
-  caniuse-lite@1.0.30001769: {}
 
   caniuse-lite@1.0.30001788: {}
 
@@ -3449,15 +3433,15 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.5.12(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 15.5.12
       '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001769
+      caniuse-lite: 1.0.30001788
       postcss: 8.4.31
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.12
       '@next/swc-darwin-x64': 15.5.12
@@ -3584,14 +3568,14 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-dom@19.2.4(react@19.2.4):
+  react-dom@19.2.5(react@19.2.5):
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
 
-  react@19.2.4: {}
+  react@19.2.5: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3679,7 +3663,7 @@ snapshots:
 
   sharp@0.34.5:
     dependencies:
-      '@img/colour': 1.0.0
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.7.4
     optionalDependencies:
@@ -3804,16 +3788,14 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@babel/core': 7.29.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  tailwindcss@4.2.0: {}
 
   tailwindcss@4.2.2: {}
 
@@ -3898,7 +3880,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.18.2: {}
+  undici-types@7.19.2: {}
 
   unrs-resolver@1.11.1:
     dependencies:


### PR DESCRIPTION
## Summary
- CI started failing on every PR/push after `pnpm/action-setup` was bumped from v4 to v6 (#132) with `ERR_PNPM_BROKEN_LOCKFILE: expected a single document in the stream`
- The lockfile parses fine locally with pnpm 10.28.1; the failure is specific to whatever version v6 was installing
- Pinning `version: 10.28.1` (matching the `packageManager` field in package.json) restores CI

## Test plan
- [ ] CI green on this PR
- [x] \`pnpm install --frozen-lockfile\` succeeds locally with pnpm 10.28.1