### PR TITLE
fix(ci): bump pnpm to 10.33.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:
@@ -32,6 +34,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "protfolio",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.28.1",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",


### PR DESCRIPTION
## 概要
#132 で `pnpm/action-setup` を v4 → v6 にバンプして以降、すべてのPR/pushで `ERR_PNPM_BROKEN_LOCKFILE: expected a single document in the stream, but found more` が発生してCIが失敗していた。

### 原因
`pnpm/action-setup@v6` の bootstrap 過程で、一時的に走るpnpm（v11系）がリポジトリの `pnpm-lock.yaml` の先頭に **env lockfile を1つ目のYAMLドキュメント** として書き込む。結果としてlockfileが多ドキュメント形式になり、古いpnpm 10.x（10.28.1 を含む）はこれをパースできず落ちる。

pnpm **10.33.0** のリリースノート: *\"When a pnpm-lock.yaml contains two documents, ignore the first one. pnpm v11 will write two lockfile documents.\"*

### 修正内容
- `package.json`: \`packageManager\` を \`pnpm@10.33.0\` に更新
- `.github/workflows/ci.yaml`: \`pnpm/action-setup@v6\` に \`version: 10.33.0\` をpin

## 動作確認
- [ ] このPRでCIがグリーンになること
- [x] ローカルで pnpm 10.33.0 にて \`pnpm install\` / \`pnpm dev\` が動作すること