### PR TITLE
update: プロフィールをクラスメソッドでの現職内容に更新

### DIFF
--- a/app/components/about/AboutContent.tsx
+++ b/app/components/about/AboutContent.tsx
@@ -32,10 +32,12 @@ export const AboutContent = ({ isDarkMode, parentRef }: AboutContentProps) => {
 
     return (
         <div ref={contentRef} className='flex-1'>
-            <p>I am a frontend engineer with two years of professional experience.<br />
-                Despite my relatively short career, I have been involved in projects where I handled everything
-                from planning and design to development.<br />
-                I have also gained experience as a team leader in engineering teams.<br />
+            <p>I am a software engineer at Classmethod, building web applications with
+                React and TypeScript on the frontend and an AWS serverless stack
+                (Lambda, DynamoDB, CDK) on the backend.<br />
+                Before joining Classmethod, I spent two years as a frontend engineer at
+                an SES company, where I handled projects end-to-end from planning and
+                design to development, and also led engineering teams.<br />
                 I constantly strive to deliver value from both user perspective and engineering standpoint,
                 while contributing to the overall productivity and quality improvement of the team.
             </p>

--- a/app/components/header/Bio.tsx
+++ b/app/components/header/Bio.tsx
@@ -25,7 +25,7 @@ export const Bio = () => {
 
     return (
         <p ref={bioRef} className='max-w-2xl mx-auto font-Ovo'>
-            I am a software developer from Japan with 2 years experience in an SES company.
+            I am a software engineer at Classmethod, based in Japan.
         </p>
     )
 }

--- a/assets/assets.ts
+++ b/assets/assets.ts
@@ -77,7 +77,7 @@ export const infoList: InfoList[] = [
         icon: assets.codeIcon,
         iconDark: assets.codeIconDark,
         title: 'Language',
-        description: 'React, Next.js, TypeScript, JavaScript, Node.js, Tailwind CSS, Vue.js, Nuxt.js.',
+        description: 'React, Next.js, TypeScript, JavaScript, Vue.js, Nuxt.js, Node.js, AWS, Git.',
     },
     {
         icon: assets.projectIcon,
@@ -97,7 +97,7 @@ export const skillsData = [
     {
         name: 'Next.js',
         icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-original.svg',
-        iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-plain.svg',
+        iconDark: 'https://cdn.simpleicons.org/nextdotjs/white',
         color: '#000000',
     },
     {

--- a/assets/assets.ts
+++ b/assets/assets.ts
@@ -77,7 +77,7 @@ export const infoList: InfoList[] = [
         icon: assets.codeIcon,
         iconDark: assets.codeIconDark,
         title: 'Language',
-        description: 'Vue.js, Nuxt.js, JavaScript, TypeScript, Node.js, React.js, Next.js, Tailwind CSS.',
+        description: 'React, Next.js, TypeScript, JavaScript, Node.js, Tailwind CSS, Vue.js, Nuxt.js.',
     },
     {
         icon: assets.projectIcon,
@@ -88,6 +88,30 @@ export const infoList: InfoList[] = [
 ]
 
 export const skillsData = [
+    {
+        name: 'React',
+        icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg',
+        iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg',
+        color: '#61DAFB',
+    },
+    {
+        name: 'Next.js',
+        icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-original.svg',
+        iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-plain.svg',
+        color: '#000000',
+    },
+    {
+        name: 'TypeScript',
+        icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg',
+        iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg',
+        color: '#007ACC',
+    },
+    {
+        name: 'JavaScript',
+        icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg',
+        iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg',
+        color: '#F7DF1E',
+    },
     {
         name: 'Vue.js',
         icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vuejs/vuejs-original.svg',
@@ -101,35 +125,22 @@ export const skillsData = [
         color: '#00DC82',
     },
     {
-        name: 'JavaScript',
-        icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg',
-        iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg',
-        color: '#F7DF1E',
-    },
-    {
-        name: 'TypeScript',
-        icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg',
-        iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg',
-
-        color: '#007ACC',
-    },
-    {
         name: 'Node.js',
         icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg',
         iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg',
         color: '#339933',
     },
     {
-        name: 'Git',
-        icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg',
-        iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg',
-        color: '#F05032',
-    },
-    {
         name: 'AWS',
         icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/amazonwebservices/amazonwebservices-plain-wordmark.svg',
         iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/amazonwebservices/amazonwebservices-plain-wordmark.svg',
         color: '#FF9900',
+    },
+    {
+        name: 'Git',
+        icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg',
+        iconDark: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg',
+        color: '#F05032',
     }
 ]
 


### PR DESCRIPTION
## 概要
現在の所属（クラスメソッド）と担当業務の実態にプロフィールを合わせる。SES時代の記述のまま古くなっていたため更新。

## 変更内容
- **Bio** (\`app/components/header/Bio.tsx\`)
  - 「SES company で2年」の記述を撤去し、「software engineer at Classmethod」に変更
- **About** (\`app/components/about/AboutContent.tsx\`)
  - 現職のスタック（React / TypeScript + AWS serverless: Lambda, DynamoDB, CDK）を追記
  - SES時代の経験（企画〜開発の一貫担当、チームリード経験）は前職経験として残す
- **Skills** (\`assets/assets.ts\`)
  - React / Next.js を追加し、現職主軸の順序に並び替え（React → Next.js → TS → JS → Vue → Nuxt → Node.js → AWS → Git）
  - \`infoList.Language\` も同じ順序に整理

## 動作確認
- [x] ローカルで \`pnpm dev\` が HTTP 200 を返すこと
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated personal profile information with current employment details and professional background
  * Reorganized technology skills list with refreshed technology focus

<!-- end of auto-generated comment: release notes by coderabbit.ai -->