### PR TITLE
fix(a11y): resolve lint warnings from Vite+ migration

### DIFF
--- a/app/components/Contact.tsx
+++ b/app/components/Contact.tsx
@@ -47,6 +47,7 @@ export const Contact = () => {
           <input
             type="text"
             placeholder="Enter your name"
+            aria-label="Your name"
             required
             className="flex-1 p-3 outline-none border-[0.5px] border-gray-400
                     rounded-md bg-white dark:bg-darkHover/30 dark:border-white/90"
@@ -56,6 +57,7 @@ export const Contact = () => {
           <input
             type="email"
             placeholder="Enter your email"
+            aria-label="Your email"
             required
             className="flex-1 p-3 outline-none border-[0.5px] border-gray-400
                     rounded-md bg-white
@@ -66,6 +68,7 @@ export const Contact = () => {
         <textarea
           rows={6}
           placeholder="Enter your message"
+          aria-label="Your message"
           required
           className="w-full p-4 outline-none border-[0.5px] border-gray-400
                 rounded-md bg-white mb-6 dark:bg-darkHover/30 dark:border-white/90"

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -95,17 +95,14 @@ export const Navbar = ({ isDarkMode, setIsDarkMode }: NavbarProps) => {
   };
 
   useEffect(() => {
-    window.addEventListener("scroll", () => {
-      if (scrollY > 50) {
-        setIsScroll(true);
-      } else {
-        setIsScroll(false);
-      }
-    });
+    const handleScroll = () => {
+      setIsScroll(scrollY > 50);
+    };
+
+    window.addEventListener("scroll", handleScroll);
 
     return () => {
-      // コンポーネントアンマウント時にイベントリスナーを削除
-      window.removeEventListener("scroll", () => {});
+      window.removeEventListener("scroll", handleScroll);
     };
   }, []);
 
@@ -188,21 +185,27 @@ export const Navbar = ({ isDarkMode, setIsDarkMode }: NavbarProps) => {
                 top-0 bottom-0 w-64 z-50 h-screen bg-rose-50 transition duration-500
                 dark:bg-darkHover dark:text-white"
         >
-          <div className="absolute top-6 right-6" onClick={closeMenu}>
+          <button
+            type="button"
+            aria-label="Close menu"
+            className="absolute top-6 right-6"
+            onClick={closeMenu}
+          >
             <Image
               src={isDarkMode ? assets.closeWhite : assets.closeBlack}
-              alt="Close Menu"
+              alt=""
               className="w-5 cursor-pointer hover:rotate-90 transition-transform duration-300"
             />
-          </div>
+          </button>
 
           {linkList.map((link, index) => (
             <li
               key={index}
               className="font-Ovo hover:translate-x-2 transition-transform duration-300"
-              onClick={closeMenu}
             >
-              <a href={link.href}>{link.name}</a>
+              <a href={link.href} onClick={closeMenu}>
+                {link.name}
+              </a>
             </li>
           ))}
         </ul>

--- a/app/components/Work.tsx
+++ b/app/components/Work.tsx
@@ -15,8 +15,9 @@ export const Work = () => {
         {workData.map((project, index) => (
           <a
             key={index}
+            aria-label={project.title}
             className='aspect-square bg-no-repeat bg-cover bg-center rounded-lg
-                        relative cursor-pointer group before:content-[""] before:absolute before:inset-0 
+                        relative cursor-pointer group before:content-[""] before:absolute before:inset-0
                         before:bg-gray-500/50  before:rounded-lg hover:before:bg-gray-500/30
                         before:transition-all before:duration-500'
             href={project.link}


### PR DESCRIPTION
## Summary

Vite+ 移行後に残っていた 9 件のアクセシビリティ lint 警告をすべて修正。

- **Navbar**: `removeEventListener` に無名関数を渡していたバグを修正（スクロールハンドラを名前付き関数に切り出し）
- **Navbar**: クローズボタンの `<div onClick>` を `<button>` に変更
- **Navbar**: モバイルメニューの `<li onClick>` を `<a onClick>` に移動（非インタラクティブ要素にイベント不可）
- **Contact**: `<input>` / `<textarea>` に `aria-label` を追加
- **Work**: プロジェクトリンクの `<a>` に `aria-label` を追加

## Test plan

- [x] `vp check` — 0 errors, 0 warnings
- [x] `pnpm build` — Next.js ビルド成功